### PR TITLE
Support for Mono

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: c
+
+env:
+  - NUODB_HOME=/opt/nuodb NUODB_VERSION=1.1.1
+
+before_install:
+  - wget http://www.nuodb.com/latest/releases/nuodb-${NUODB_VERSION}.linux.x64.deb --output-document=/var/tmp/nuodb.deb
+  - sudo dpkg -i /var/tmp/nuodb.deb
+  - sleep 2
+
+install:
+ - sudo apt-get update && sudo apt-get install mono-devel mono-gmcs mono-complete cli-common-dev nunit-console
+
+before_script:
+  - ${NUODB_HOME}/bin/nuodb --chorus test --password bar --dba-user dba --dba-password goalie --verbose debug --archive /var/tmp/nuodb --initialize --force &
+  - sleep 2
+  - ${NUODB_HOME}/bin/nuodb --chorus test --password bar --dba-user dba --dba-password goalie &
+  - sleep 2
+
+script:
+ - xbuild /p:TargetFrameworkProfile="" /p:Configuration=Release NuoDb.Data.Client/Mono.NuoDb.Data.Client_3.5.csproj
+ - sudo gacutil -i NuoDb.Data.Client/bin/Release35/NuoDb.Data.Client.dll
+ - xbuild /p:TargetFrameworkProfile="" /p:Configuration=Release NuoDb.Data.Client/Mono.NuoDb.Data.Client_4.0.csproj
+ - sudo gacutil -i NuoDb.Data.Client/bin/Release40/NuoDb.Data.Client.dll
+ - xbuild /p:TargetFrameworkProfile="" /p:Configuration=Release ConsoleSample/ConsoleSample.csproj
+ - ConsoleSample/bin/Release/ConsoleSample.exe test
+
+notifications:
+  recipients:
+    - buck.robert.j@gmail.com
+

--- a/NUnitTestProject/Mono.NUnitTestProject.csproj
+++ b/NUnitTestProject/Mono.NUnitTestProject.csproj
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{B4BDA7ED-BF93-42F9-BD28-D8F5725C44F3}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NUnitTestProject</RootNamespace>
+    <AssemblyName>NUnitTestProject</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+    <FileAlignment>512</FileAlignment>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit-console-runner">
+      <HintPath>NUnit\nunit-console-runner.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.5.10.11092, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>NUnit\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Security" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestFixture.cs" />
+    <Compile Include="Utils.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.Config" />
+    <None Include="NUnit\nunit-console-runner.dll" />
+    <None Include="NUnit\nunit.framework.dll" />
+    <None Include="NUnit\nunit.mocks.dll" />
+    <None Include="NUnit\nunit.util.dll" />
+    <None Include="NUnit\nunit.core.interfaces.dll" />
+    <None Include="NUnit\nunit.core.dll" />
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include=".NETFramework,Version=v4.0,Profile=Client">
+      <Visible>False</Visible>
+      <ProductName>Microsoft .NET Framework 4 Client Profile %28x86 and x64%29</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Windows.Installer.3.1">
+      <Visible>False</Visible>
+      <ProductName>Windows Installer 3.1</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NuoDb.Data.Client\NuoDb.Data.Client_4.0.csproj">
+      <Project>{3A992E63-061C-47EE-862A-452334D70D90}</Project>
+      <Name>NuoDb.Data.Client_4.0</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/NUnitTestProject/TestFixture.cs
+++ b/NUnitTestProject/TestFixture.cs
@@ -16,11 +16,19 @@ namespace NUnitTestProject
         static string password = "goalie";
         static string database = "test";
         static string schema = "hockey";
-        static internal string connectionString = "Server=  " + host + "; Database=\"" + database + "\"; User = " + user + " ;Password   = '" + password + "';Schema=\"" + schema + "\"";
+        static internal string connectionString;
 
         [TestFixtureSetUp]
         public static void Init()
         {
+            NuoDbConnectionStringBuilder builder = new NuoDbConnectionStringBuilder();
+            builder.Server = host;
+            builder.Database = database;
+            builder.User = user;
+            builder.Password = password;
+            builder.Schema = schema;
+            connectionString = builder.ConnectionString;
+
             Utils.CreateHockeyTable();
         }
 

--- a/NuoDb.Data.Client/Mono.NuoDb.Data.Client_3.5.csproj
+++ b/NuoDb.Data.Client/Mono.NuoDb.Data.Client_3.5.csproj
@@ -1,0 +1,118 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{0660AC83-4B1B-4DE0-9D8E-6049DE12E0CD}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NuoDb.Data.Client</RootNamespace>
+    <AssemblyName>NuoDb.Data.Client</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug35\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release35\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Transactions" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="BatchProcessedEventArgs.cs" />
+    <Compile Include="BatchProcessedEventHandler.cs" />
+    <Compile Include="ConnectionPoolManager.cs" />
+    <Compile Include="Net\SocketListener.cs" />
+    <Compile Include="NuoDbBulkLoader.cs" />
+    <Compile Include="NuoDbBulkLoaderColumnMapping .cs" />
+    <Compile Include="NuoDbBulkLoaderColumnMappingCollection.cs" />
+    <Compile Include="NuoDbCommandBuilder.cs" />
+    <Compile Include="NuoDbConnectionInternal.cs" />
+    <Compile Include="NuoDbConnectionStringBuilder.cs" />
+    <Compile Include="NuoDbDataAdapter.cs" />
+    <Compile Include="NuoDbDataParameterCollection.cs" />
+    <Compile Include="NuoDbParameter.cs" />
+    <Compile Include="NuoDbProviderFactory.cs" />
+    <Compile Include="NuoDbRowUpdatedEventHandler.cs" />
+    <Compile Include="NuoDbRowUpdatingEventHandler.cs" />
+    <Compile Include="NuoDbTransaction.cs" />
+    <Compile Include="Protocol.cs" />
+    <Compile Include="RemEncodedStream.cs" />
+    <Compile Include="Security\BigInteger.cs" />
+    <Compile Include="Security\RemoteGroup.cs" />
+    <Compile Include="Security\RemotePassword.cs" />
+    <Compile Include="NuoDbSqlCode.cs" />
+    <Compile Include="Util\Extensions.cs" />
+    <Compile Include="Util\Op.cs" />
+    <Compile Include="Util\StringUtils.cs" />
+    <Compile Include="ValueBytes.cs" />
+    <Compile Include="Xml\Attribute.cs" />
+    <Compile Include="NuoDbCommand.cs" />
+    <Compile Include="NuoDbConnection.cs" />
+    <Compile Include="Net\CryptoInputStream.cs" />
+    <Compile Include="Net\CryptoOutputStream.cs" />
+    <Compile Include="Net\CryptoSocket.cs" />
+    <Compile Include="Security\Cypher.cs" />
+    <Compile Include="Security\CypherRC4.cs" />
+    <Compile Include="NuoDbDataReader.cs" />
+    <Compile Include="DataStream.cs" />
+    <Compile Include="Xml\Doc.cs" />
+    <Compile Include="EncodedDataStream.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="NuoDbSqlException.cs" />
+    <Compile Include="Xml\Tag.cs" />
+    <Compile Include="Value.cs" />
+    <Compile Include="ValueBoolean.cs" />
+    <Compile Include="ValueByte.cs" />
+    <Compile Include="ValueDate.cs" />
+    <Compile Include="ValueDouble.cs" />
+    <Compile Include="ValueInt.cs" />
+    <Compile Include="ValueLong.cs" />
+    <Compile Include="ValueNull.cs" />
+    <Compile Include="ValueNumber.cs" />
+    <Compile Include="ValueShort.cs" />
+    <Compile Include="ValueString.cs" />
+    <Compile Include="ValueTime.cs" />
+    <Compile Include="ValueTimestamp.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="DataTypes.xml" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/NuoDb.Data.Client/Mono.NuoDb.Data.Client_4.0.csproj
+++ b/NuoDb.Data.Client/Mono.NuoDb.Data.Client_4.0.csproj
@@ -1,0 +1,122 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{3A992E63-061C-47EE-862A-452334D70D90}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NuoDb.Data.Client</RootNamespace>
+    <AssemblyName>NuoDb.Data.Client</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug40\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;NET_40</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release40\</OutputPath>
+    <DefineConstants>TRACE;NET_40</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Transactions" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="BatchProcessedEventArgs.cs" />
+    <Compile Include="BatchProcessedEventHandler.cs" />
+    <Compile Include="ConnectionPoolManager.cs" />
+    <Compile Include="Net\SocketListener.cs" />
+    <Compile Include="NuoDbBulkLoader.cs" />
+    <Compile Include="NuoDbBulkLoaderColumnMapping .cs" />
+    <Compile Include="NuoDbBulkLoaderColumnMappingCollection.cs" />
+    <Compile Include="NuoDbCommandBuilder.cs" />
+    <Compile Include="NuoDbConnection.cs" />
+    <Compile Include="NuoDbConnectionStringBuilder.cs" />
+    <Compile Include="NuoDbDataAdapter.cs" />
+    <Compile Include="NuoDbDataParameterCollection.cs" />
+    <Compile Include="NuoDbParameter.cs" />
+    <Compile Include="NuoDbProviderFactory.cs" />
+    <Compile Include="NuoDbRowUpdatedEventHandler.cs" />
+    <Compile Include="NuoDbRowUpdatingEventHandler.cs" />
+    <Compile Include="NuoDbTransaction.cs" />
+    <Compile Include="Protocol.cs" />
+    <Compile Include="RemEncodedStream.cs" />
+    <Compile Include="Security\BigInteger.cs" />
+    <Compile Include="Security\RemoteGroup.cs" />
+    <Compile Include="Security\RemotePassword.cs" />
+    <Compile Include="NuoDbSqlCode.cs" />
+    <Compile Include="Util\Extensions.cs" />
+    <Compile Include="Util\Op.cs" />
+    <Compile Include="Util\StringUtils.cs" />
+    <Compile Include="ValueBytes.cs" />
+    <Compile Include="Xml\Attribute.cs" />
+    <Compile Include="NuoDbCommand.cs" />
+    <Compile Include="NuoDbConnectionInternal.cs" />
+    <Compile Include="Net\CryptoInputStream.cs" />
+    <Compile Include="Net\CryptoOutputStream.cs" />
+    <Compile Include="Net\CryptoSocket.cs" />
+    <Compile Include="Security\Cypher.cs" />
+    <Compile Include="Security\CypherRC4.cs" />
+    <Compile Include="NuoDbDataReader.cs" />
+    <Compile Include="DataStream.cs" />
+    <Compile Include="Xml\Doc.cs" />
+    <Compile Include="EncodedDataStream.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="NuoDbSqlException.cs" />
+    <Compile Include="Xml\Tag.cs" />
+    <Compile Include="Value.cs" />
+    <Compile Include="ValueBoolean.cs" />
+    <Compile Include="ValueByte.cs" />
+    <Compile Include="ValueDate.cs" />
+    <Compile Include="ValueDouble.cs" />
+    <Compile Include="ValueInt.cs" />
+    <Compile Include="ValueLong.cs" />
+    <Compile Include="ValueNull.cs" />
+    <Compile Include="ValueNumber.cs" />
+    <Compile Include="ValueShort.cs" />
+    <Compile Include="ValueString.cs" />
+    <Compile Include="ValueTime.cs" />
+    <Compile Include="ValueTimestamp.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="DataTypes.xml" />
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/NuoDb.Data.Client/NuoDbProviderFactory.cs
+++ b/NuoDb.Data.Client/NuoDbProviderFactory.cs
@@ -29,12 +29,18 @@
 using System.Data.Common;
 using System.Security;
 using System.Security.Permissions;
+#if !__MonoCS__
 using NuoDb.Data.Client.EntityFramework;
+#endif
 using System;
 
 namespace NuoDb.Data.Client
 {
+#if !__MonoCS__
     public class NuoDbProviderFactory : DbProviderFactory, IServiceProvider
+#else
+    public class NuoDbProviderFactory : DbProviderFactory
+#endif
     {
         public static readonly NuoDbProviderFactory Instance = new NuoDbProviderFactory();
 
@@ -83,7 +89,7 @@ namespace NuoDb.Data.Client
             return null;
         }
 
-
+#if !__MonoCS__
         #region IServiceProvider Members
 
         public object GetService(Type serviceType)
@@ -99,5 +105,6 @@ namespace NuoDb.Data.Client
         }
 
         #endregion
+#endif
     }
 }

--- a/README.md
+++ b/README.md
@@ -3,4 +3,6 @@ nuodb-dotnet
 
 .NET Driver for NuoDB
 
+[![Build Status](https://travis-ci.org/rbuck/nuodb-dotnet.png)](https://travis-ci.org/rbuck/nuodb-dotnet)
+
 [![githalytics.com alpha](https://cruel-carlota.pagodabox.com/bfba91991b4f1616327840d4cd039bc1 "githalytics.com")](http://githalytics.com/nuodb/nuodb-dotnet)


### PR DESCRIPTION
- Add support for building against .NET 3.5.
- Add support for building against .NET 4.0.
- Add assemblies to GAC to validate they install properly.
- Add execution of console sample as a test.
- Update test suite to only run DbConnection related tests on Mono.
- Update test suite to use connection string builder to avoid malformed
  malformed connection specs, an issue with Mono and the hard coded
  scheme that previously existed.
- Add nunit-console to the list of dependencies installed.
