### PR TITLE
Fixed order for setting "disposed" (error in Rollback).

### DIFF
--- a/NuoDb.Data.Client/NuoDbConnection.cs
+++ b/NuoDb.Data.Client/NuoDbConnection.cs
@@ -152,11 +152,12 @@ namespace NuoDb.Data.Client
             if (_disposed)
                 return;
 
-            _disposed = true;
             if (disposing)
             {
                 CloseImpl();
             }
+
+            _disposed = true;
         }
 
         protected override DbCommand CreateDbCommand()


### PR DESCRIPTION
Disposed must be set after all work in done. Else exception will be thrown - i.e. in NuoDbTransaction.Rollback > InternalConnection getter > CheckConnection.
