### PR TITLE
Increase sleeps in TestFixture.cs to avoid test failures

### DIFF
--- a/NUnitTestProject/TestFixture.cs
+++ b/NUnitTestProject/TestFixture.cs
@@ -1399,7 +1399,7 @@ namespace NUnitTestProject
                 pooledItems = NuoDbConnection.GetPooledConnectionCount(cnn);
                 Assert.AreEqual(2, pooledItems);
 
-                Thread.Sleep(3000);
+                Thread.Sleep(13000);
 
                 // 1 busy
                 pooledItems = NuoDbConnection.GetPooledConnectionCount(cnn);
@@ -1423,7 +1423,7 @@ namespace NUnitTestProject
             pooledItems = NuoDbConnection.GetPooledConnectionCount(newConnString);
             Assert.AreEqual(1, pooledItems);
 
-            Thread.Sleep(3000);
+            Thread.Sleep(13000);
 
             // empty pool
             pooledItems = NuoDbConnection.GetPooledConnectionCount(newConnString);


### PR DESCRIPTION
Those parts of the test seem to test the ability of the connection pool to shrink back. My reading of the code is that the connection pool may keep connections for up to 10 seconds and that checks for idleness are only performed once every 1 second.