### PR TITLE
Add CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,95 @@
+version: 2.1
+
+orbs:
+  windows: circleci/windows@5.0
+
+jobs:
+  build-test-linux:
+    machine:
+      image: ubuntu-2004:2024.11.1
+    resource_class: medium
+    environment:
+      IMG_NAME: "nuodb/nuodb:6.0.2-9"
+    steps:
+      - checkout
+      - run:
+          name: Add dotnet repo
+          command: |
+            wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+            sudo dpkg -i packages-microsoft-prod.deb
+            rm packages-microsoft-prod.deb
+      - run:
+          name: Install make
+          command: sudo apt update && sudo apt install -y dotnet-sdk-6.0 dotnet-sdk-8.0
+      - run:
+          name: Install JetBrains dotCover CLI and Logger package
+          command: |
+            dotnet tool install --global JetBrains.dotCover.GlobalTool
+            dotnet add NuoDb.EntityFrameworkCore.Tests/NuoDb.EntityFrameworkCore.Tests.csproj package JunitXml.TestLogger
+      - run:
+          name: Restore packages
+          command: dotnet restore NuoDb.EntityFrameworkCore.NuoDb/NuoDb.EntityFrameworkCore.NuoDb.csproj
+      - run:
+          name: Build solution
+          command: dotnet build --configuration Debug --no-restore NuoDb.EntityFrameworkCore.NuoDb/NuoDb.EntityFrameworkCore.NuoDb.csproj
+      - run:
+          name: Restore test packages
+          command: dotnet restore NuoDb.EntityFrameworkCore.Tests/NuoDb.EntityFrameworkCore.Tests.csproj
+      - run:
+          name: Build test solution
+          command: dotnet build --configuration Debug --no-restore NuoDb.EntityFrameworkCore.Tests/NuoDb.EntityFrameworkCore.Tests.csproj
+      - run:
+          name: Start NuoDB test database
+          command: ls -las && env && make up
+      - run:
+          name: Run tests
+          command: |
+            sudo timedatectl set-timezone America/New_York
+            export PATH="$PATH:$HOME/.dotnet/tools"
+            dotnet dotcover test \
+              --dcOutput=test-results/dotNetCoverage.html \
+              --dcReportType=HTML \
+              --dcfilters="-:module=Humanizer;-:module=NuoDb.EntityFrameworkCore.Tests;-:type=JetBrains.*;-:type=System.*;-:type=Microsoft.*" \
+              NuoDb.EntityFrameworkCore.Tests/NuoDb.EntityFrameworkCore.Tests.csproj \
+              --logger="junit;LogFilePath=./TestResults/test-results.xml"
+      - run:
+          name: Make sure we clean the test environment
+          command: make dn
+      - store_artifacts:
+          path: test-results
+          destination: coverage-report
+      - store_test_results:
+          path: NuoDb.EntityFrameworkCore.Tests/TestResults
+
+  build-test-windows:
+    executor:
+      name: windows/default
+    steps:
+      - checkout
+      - run:
+          name: Install .NET 8 SDK
+          command: |
+            $ProgressPreference = 'SilentlyContinue'
+            Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile "dotnet-install.ps1"
+            ./dotnet-install.ps1 -Channel 8.0 -Quality GA
+      - run:
+          name: Restore packages
+          command: dotnet restore NuoDb.EntityFrameworkCore.NuoDb/NuoDb.EntityFrameworkCore.NuoDb.csproj
+      - run:
+          name: Build solution
+          command: dotnet build --configuration Release --no-restore NuoDb.EntityFrameworkCore.NuoDb/NuoDb.EntityFrameworkCore.NuoDb.csproj
+      - run:
+          name: Restore test packages
+          command: dotnet restore NuoDb.EntityFrameworkCore.Tests/NuoDb.EntityFrameworkCore.Tests.csproj
+      - run:
+          name: Build test solution
+          command: dotnet build --configuration Release --no-restore NuoDb.EntityFrameworkCore.Tests/NuoDb.EntityFrameworkCore.Tests.csproj
+
+workflows:
+  # Workflow for commits - only build and test
+  build-and-test:
+    jobs:
+      - build-test-linux:
+          context:
+            - common-config
+      - build-test-windows

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+# Copyright (c) 2025, Dassault Systèmes SE
+# All rights reserved.
+#
+# Redistribution and use permitted under the terms of the 3-clause BSD license.
+
+TTY:=-it
+ifdef NO_TTY
+	TTY:=-t
+endif
+
+#:help: help        | Displays the GNU makefile help
+.PHONY: help
+help: ; @sed -n 's/^#:help://p' Makefile
+
+#:help: up          | Starts up a NuoDB cluster
+.PHONY: up
+up:
+	scripts/up
+
+#:help: status      | Shows the NuoDB cluster status
+.PHONY: status
+status:
+	scripts/status
+
+#:help: term        | Opens up a terminal to a running NuoDB cluster
+.PHONY: term
+term:
+	@echo "Welcome to NuoDB"
+	@echo ""
+	@echo "   To open a SQL prompt run the following command:"
+	@echo "      nuosql test@ad1 --user dba --password dba"
+	@echo ""
+	@echo "   To show what's running in the domain run the following command:"
+	@echo "      nuocmd --api-server ad1:8888 show domain"
+	@echo ""
+	@echo "   To get out the terminal simply type exit."
+	@echo ""
+	@scripts/term
+
+#:help: dn          | Stops the NuoDB cluster
+.PHONY: dn
+dn:
+	scripts/dn

--- a/scripts/dn
+++ b/scripts/dn
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+echo "Stopping NuoDB environment.... "
+containers=("te1" "te2" "sm1" "ad1")
+for container in "${containers[@]}"; do
+    if docker ps -a | grep -q "$container"; then
+        echo -n "- "
+        docker stop "$container"
+    else
+        echo "'$container' alredy stopped."
+    fi
+done
+echo "Done!"
+echo
+echo -n "Remove local network... "
+if docker network rm nuodb-net 2>/dev/null; then
+    echo "Done!"
+else
+    echo "Local network already removed."
+fi
+
+echo
+echo "Remove local volumes..."
+for vol in vol1 vol2 cores valgrind; do
+    echo -n "- "
+    docker volume rm "$vol" 2>/dev/null || echo "'$vol' volume already removed."
+done
+echo "Done!"
+echo
+echo "Environment cleaned."

--- a/scripts/status
+++ b/scripts/status
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+: ${IMG_NAME:="nuodb/nuodb:latest"}
+
+docker run -it --net nuodb-net ${IMG_NAME} \
+    nuocmd --api-server ad1:8888 show domain
+

--- a/scripts/term
+++ b/scripts/term
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+: ${IMG_NAME:="nuodb/nuodb:latest"}
+
+docker run -it --name term --rm \
+    --net nuodb-net ${IMG_NAME} bash

--- a/scripts/up
+++ b/scripts/up
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+: ${IMG_NAME:="nuodb/nuodb:latest"}
+
+if [ -z "${NUODB_LIMITED_LICENSE_CONTENT}" ] && [ -z "${NUODB_LIMITED_LICENSE}" ]; then
+	echo "Need a license setting"
+	exit -1
+fi
+
+COMMAND="docker exec ad1 nuocmd check database --db-name demo --check-running"
+if $COMMAND 2>/dev/null; then
+    echo "Environment already created."
+    docker exec ad1 nuocmd show domain
+    exit 0
+fi
+
+echo "Creating local network.... "
+docker network create nuodb-net
+echo "Done!"
+echo
+echo "Creating AP... "
+docker run -d --name ad1 --rm \
+    --hostname ad1 \
+    --net nuodb-net \
+    -p 8888:8888 \
+    -p 48004:48004 \
+    -p 48005:48005 \
+    -e "NUODB_DOMAIN_ENTRYPOINT=ad1" \
+    "${IMG_NAME}" nuoadmin
+echo "Done!"
+echo
+echo -n "Wating for AP to start... "
+docker exec ad1 nuocmd check servers --check-leader --check-connected --timeout 30
+echo "Connected!"
+
+# Apply limited license
+echo "Applying license.. "
+if [ -n "${NUODB_LIMITED_LICENSE_CONTENT}" ]; then
+    echo "using LICENSE CONTENT"
+    docker exec -e "NUODB_LIMITED_LICENSE_CONTENT=${NUODB_LIMITED_LICENSE_CONTENT}" ad1 /bin/bash -c 'echo "${NUODB_LIMITED_LICENSE_CONTENT}" | base64 -d > ~/nuodb.lic && /opt/nuodb/bin/nuocmd set license --license-file ~/nuodb.lic && rm ~/nuodb.lic'
+elif [ -n "${NUODB_LIMITED_LICENSE}" ]; then
+    echo "using LICENSE"
+    docker cp ${NUODB_LIMITED_LICENSE} ad1:/tmp/nuodb.lic
+    docker exec ad1 /opt/nuodb/bin/nuocmd set license --license-file /tmp/nuodb.lic
+else
+    echo "No License applied"
+fi
+echo "Done!"
+echo
+#changed to properly create and mount volumes
+echo "Creating volumes for SM... "
+echo -e "- "; docker volume create vol1
+echo -e "- "; docker volume create vol2
+echo "Done!"
+echo
+echo "Starting SM1... "
+docker run -d --name sm1 --hostname sm1 --rm \
+    --volume vol1:/var/opt/nuodb/backup \
+    --volume vol2:/var/opt/nuodb/archive \
+    --net nuodb-net "${IMG_NAME}" nuodocker \
+    --api-server ad1:8888 start sm \
+    --db-name demo --server-id ad1 \
+    --dba-user dba --dba-password dba \
+    --labels "zone east node localhost" \
+    --archive-dir /var/opt/nuodb/archive
+echo "Done!"
+echo
+echo "Starting TEs... "
+docker run -d --name te1 --hostname te1 --rm \
+    --net nuodb-net "${IMG_NAME}" nuodocker \
+    --api-server ad1:8888 start te \
+    --db-name demo --server-id ad1
+
+docker run -d --name te2 --hostname te2 --rm \
+    --net nuodb-net "${IMG_NAME}" nuodocker \
+    --api-server ad1:8888 start te \
+    --db-name demo --server-id ad1
+echo "Done!"
+echo
+echo -n "Waiting for database to start..."
+COMMAND="docker exec ad1 nuocmd check database --db-name demo --check-running"
+while ! $COMMAND 2>/dev/null; do
+    echo -n "."
+    sleep 2
+done
+echo " Running!"
+echo
+docker exec ad1 nuocmd show domain


### PR DESCRIPTION
Runs build and test on linux.
Only runs build on Windows since it needs a live NuoDB database to test which is not available.

Collects code-coverage and test results at the end and makes them available on CircleCI tests and artifacts panel sections.