### PR TITLE
Change dotCover command and add support for Junit Logger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,10 +46,10 @@ jobs:
           command: |
             sudo timedatectl set-timezone America/New_York
             export PATH="$PATH:$HOME/.dotnet/tools"
-            dotnet dotcover test \
-              --dcOutput=test-results/dotNetCoverage.html \
-              --dcReportType=HTML \
-              --dcfilters="-:module=Humanizer;-:module=NuoDb.EntityFrameworkCore.Tests;-:type=JetBrains.*;-:type=System.*;-:type=Microsoft.*" \
+            dotCover dotnet \
+              --Output="test-results/dotNetCoverage.html" \
+              --ReportType="HTML" \
+              --Filters="-:module=Humanizer;-:module=NuoDb.EntityFrameworkCore.Tests;-:type=JetBrains.*;-:type=System.*;-:type=Microsoft.*" -- test \
               NuoDb.EntityFrameworkCore.Tests/NuoDb.EntityFrameworkCore.Tests.csproj \
               --logger="junit;LogFilePath=./TestResults/test-results.xml"
       - run:

--- a/NuoDb.EntityFrameworkCore.Tests/NuoDb.EntityFrameworkCore.Tests.csproj
+++ b/NuoDb.EntityFrameworkCore.Tests/NuoDb.EntityFrameworkCore.Tests.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
+    <PackageReference Include="JunitXml.TestLogger" Version="6.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational.Specification.Tests" Version="8.0.11" />


### PR DESCRIPTION
This is a required fix after changing the code cover tool to JetBrains.dotCover.CommandLineTools.