### PR TITLE
Schema Migration History Fix

### DIFF
--- a/NuoDb.EntityFrameworkCore.NuoDb/Migrations/Internal/NuoDbHistoryRepository.cs
+++ b/NuoDb.EntityFrameworkCore.NuoDb/Migrations/Internal/NuoDbHistoryRepository.cs
@@ -48,12 +48,12 @@ namespace NuoDb.EntityFrameworkCore.NuoDb.Migrations.Internal
             get
             {
                 var stringTypeMapping = Dependencies.TypeMappingSource.GetMapping(typeof(string));
-
+                var schemaName = stringTypeMapping.GenerateSqlLiteral(TableSchema);
+                var schemaCriteria = (string.IsNullOrWhiteSpace(schemaName) || schemaName == "NULL") ? "": $"\" AND \"SCHEMA\"= \"{schemaName}";
                 return
                     $"SELECT COUNT(*) FROM \"SYSTEM\".\"TABLES\" WHERE \"TABLENAME\" = "
                     + stringTypeMapping.GenerateSqlLiteral(TableName)
-                    + " AND \"SCHEMA\"= "
-                    + stringTypeMapping.GenerateSqlLiteral(TableSchema)
+                    + schemaCriteria
                     + " AND \"TYPE\" = 'TABLE'";
             }
         }


### PR DESCRIPTION
EFCore was passing 'NULL' in as a string for schema when providing a check to check whether the `__EFMigrationsHistory` table existed.

At the time the SQL is executed, the context should already be set to the target schema, and theoretically dont ever need to provide the schema criteria.

Fixed the SQL generation to include the schema filter only when the schema provided meets following criteria.
- Schema is not null
- Schema is not an empty or "whitespace" string
- Schema value is not `NULL`

I ran all unit tests, and everything passes. Verified with a sample test app that only unapplied migrations are applied.